### PR TITLE
Fix - Data portal - encode the 'name' parameter when in the query

### DIFF
--- a/src/components/FiltersOrganizations.js
+++ b/src/components/FiltersOrganizations.js
@@ -184,6 +184,10 @@ const FiltersOrganizations = (props) => {
       createdAtEnd,
     };
 
+    if(name.length > 0){
+      query.name = encodeURIComponent(name)
+    }
+
     if (serviceArea?.length > 0) {
       query.serviceArea = serviceArea;
     }
@@ -231,6 +235,7 @@ const FiltersOrganizations = (props) => {
     if (createdAtEnd) {
       query.createdAtEnd = new Date(createdAtEnd).toISOString();
     }
+
     updateQuery(query);
   };
 


### PR DESCRIPTION
## Description
The issue was that since the search was changed up a bit, the query stopped working for organization names that had special characters such the plus sign (+). Typing the name of an org in the Name field of Filter Organizations would list the name, but if you were to select that name and click on the Search button, the search would result in 0 organizations found.

The fix:
encode the 'name' parameter when in the query because the plus sign was being automatically stripped from the parameter value.

## Asana ticket:

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`? If your PR is a hotfix, is it targeted for `master`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

1. In the Data portal, Create an org with a name like "Black LGBTQIA+ Migrant Project (BLMP)" (notice the plus sign (+) )
2. From the main data portal screen, enter "Black LGBTQIA+" in the Filter Organizations -> Name field
3. When the above org is listed, select it, then, click on the "Search" button
4. The org should be found and listed
5. Click on view Org, ensure the org details are loaded

